### PR TITLE
Fix edit links for posts in folders

### DIFF
--- a/themes/stapelberg/layouts/_default/single.html
+++ b/themes/stapelberg/layouts/_default/single.html
@@ -38,7 +38,7 @@
   </div>
   {{ end }}
   <div>
-    <a href="https://github.com/stapelberg/hugo/edit/master/content/posts/{{ .File.LogicalName }}"><img src="{{ "Bilder/pen-square-solid.svg" | relURL }}" width="18" height="20" alt="Edit Icon" title="Suggest a change to this article"></a>
+    <a href="https://github.com/stapelberg/hugo/edit/master/content/{{ .File.Path }}"><img src="{{ "Bilder/pen-square-solid.svg" | relURL }}" width="18" height="20" alt="Edit Icon" title="Suggest a change to this article"></a>
   </div>
   {{ if .Params.tweet_url }}
   <div>


### PR DESCRIPTION
Looks like posts like https://michael.stapelberg.ch/posts/2020-08-09-fiber-link-home-network/ have a [broken edit](https://github.com/stapelberg/hugo/edit/master/content/posts/index.markdown) links since it does not account for the subfolder.

This PR aims to fix this.